### PR TITLE
add page size to GET parameters when collection is fetched

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,7 @@ Instantiate a new `InfiniScroll` object after your Backbone view has been render
       error: function(){ },
       target: $(window),
       param: "until",
+      pageSizeParam: "page_size",
       untilAttr: "id",
       pageSize: collection.length,
       scrollOffset: 100,
@@ -42,6 +43,7 @@ Instantiate a new `InfiniScroll` object after your Backbone view has been render
 * `param` - GET param used when `collection.fetch` is called
 * `untilAttr` - The GET param attribute used when `collection.fetch` is called. Finds last record in collection and uses this param as key. Can be a function name on the model, which you can used as a computed property.
 * `pageSize` - Used internally to determine when fetching of pages is completed.
+* `pageSizeParam` - GET param used to send page size when `collection.fetch` is called.
 * `scrollOffset` - Pixel count from bottom of page to offset the scroll for when to trigger `collection.fetch`
 * `add` - Passed to collection fetch to either add new records to the collection of perform a normal reset
 * `strict` - Used to determine when to stop fetching. Strict on will fetch until the response size is less than the page size (This can save on extra request being made to the server, but requires the response size to be consistent). Strict off will fetch until the response length is equal to 0 (better for varying page size responses).

--- a/lib/infiniScroll.js
+++ b/lib/infiniScroll.js
@@ -22,6 +22,7 @@
       onFetch: function(){ },
       target: $(window),
       param: "until",
+      pageSizeParam: "page_size",
       untilAttr: "id",
       pageSize: pageSize,
       scrollOffset: 100,
@@ -99,6 +100,8 @@
       var params = { };
 
       params[self.options.param] = typeof(model[self.options.untilAttr]) === "function" ? model[self.options.untilAttr]() : model.get(self.options.untilAttr);
+
+      params[self.options.pageSizeParam] = self.options.pageSize
 
       if (self.options.includePage) {
         params["page"] = page + 1;

--- a/spec/infiniScroll_spec.js
+++ b/spec/infiniScroll_spec.js
@@ -138,6 +138,7 @@ describe("InfiniScroll", function() {
 
         queryParams = { };
         queryParams[infini.options.param] = collection.last().get(infini.options.untilAttr);
+        queryParams[infini.options.pageSizeParam] = infini.options.pageSize;
 
         collection.length = 50;
       });
@@ -166,6 +167,7 @@ describe("InfiniScroll", function() {
           infini = new Backbone.InfiniScroll(collection, {includePage: true});
           queryParams[infini.options.param] = collection.last().get(infini.options.untilAttr);
           queryParams["page"] = 2;
+          queryParams[infini.options.pageSizeParam] = infini.options.pageSize;
 
           infini.watchScroll(event);
           expect(collection.fetch).toHaveBeenCalledWith({success: infini.fetchSuccess, error: infini.fetchError, add: true, data: queryParams});


### PR DESCRIPTION
I needed the ability to know how large a page should be on the server side, without duplicating that value across the server and the client. This is for a situation where the model's untilAttr could not be used, because the lookup is not by the id, or any computed property.
