### PR TITLE
Add `disableDefaultParams` option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,8 @@ Instantiate a new `InfiniScroll` object after your Backbone view has been render
       scrollOffset: 100,
       remove: false,
       strict: false,
-      includePage: false
+      includePage: false,
+      disableDefaultParams: false
     }
 
 * `success` - Success callback function called when `collection.fetch` is successful
@@ -55,3 +56,4 @@ Instantiate a new `InfiniScroll` object after your Backbone view has been render
 * `remove` - Passed to collection fetch to add new records to the collection without removing existing ones
 * `strict` - Used to determine when to stop fetching. Setting strict on will fetch until the response size is less than the page size (This can save one extra request being made to the server, but requires the response size to be consistent). Setting strict off will fetch until the response length is equal to 0 (better for varying page size responses).
 * `includePage` - Boolean to include the next page in the query params eg. "&page=2".
+* `disableDefaultParams` - Boolean to exclude default 'until' and 'page_size' params from the fetch.

--- a/README.markdown
+++ b/README.markdown
@@ -56,4 +56,4 @@ Instantiate a new `InfiniScroll` object after your Backbone view has been render
 * `remove` - Passed to collection fetch to add new records to the collection without removing existing ones
 * `strict` - Used to determine when to stop fetching. Setting strict on will fetch until the response size is less than the page size (This can save one extra request being made to the server, but requires the response size to be consistent). Setting strict off will fetch until the response length is equal to 0 (better for varying page size responses).
 * `includePage` - Boolean to include the next page in the query params eg. "&page=2".
-* `disableDefaultParams` - Boolean to exclude default 'until' and 'page_size' params from the fetch.
+* `disableDefaultParams` - Boolean to exclude default `until` and `page_size` params from the fetch.

--- a/lib/infiniScroll.js
+++ b/lib/infiniScroll.js
@@ -29,7 +29,8 @@
       scrollOffset: 100,
       remove: false,
       strict: false,
-      includePage: false
+      includePage: false,
+      disableDefaultParams: false
     });
 
     var initialize = function() {
@@ -106,8 +107,10 @@
     function buildQueryParams(model) {
       var params = { };
 
-      params[self.options.param] = typeof(model[self.options.untilAttr]) === "function" ? model[self.options.untilAttr]() : model.get(self.options.untilAttr);
-      params[self.options.pageSizeParam] = self.options.pageSize;
+      if (!self.options.disableDefaultParams) {
+        params[self.options.param] = typeof(model[self.options.untilAttr]) === "function" ? model[self.options.untilAttr]() : model.get(self.options.untilAttr);
+        params[self.options.pageSizeParam] = self.options.pageSize;
+      }
 
       if (self.options.includePage) {
         params["page"] = page + 1;

--- a/spec/infiniScroll_spec.js
+++ b/spec/infiniScroll_spec.js
@@ -50,6 +50,7 @@ describe("InfiniScroll", function() {
       expect(infini.options.scrollOffset).toEqual(100);
       expect(infini.options.remove).toEqual(false);
       expect(infini.options.includePage).toEqual(false);
+      expect(infini.options.disableDefaultParams).toEqual(false);
     });
   });
 


### PR DESCRIPTION
When using infiniScroll.js such functionality would've made the requests cleaner as we were sending models' ids as param
