### PR TITLE
Parse response before checking length

### DIFF
--- a/lib/infiniScroll.js
+++ b/lib/infiniScroll.js
@@ -63,7 +63,8 @@
     };
 
     self.fetchSuccess = function(collection, response) {
-      if ((self.options.strict && collection.length >= (page + 1) * self.options.pageSize) || (!self.options.strict && response.length > 0)) {
+      var parsedResponse = collection.parse(response);
+      if ((self.options.strict && collection.length >= (page + 1) * self.options.pageSize) || (!self.options.strict && parsedResponse.length > 0)) {
         self.enableFetch();
         page += 1;
       } else {


### PR DESCRIPTION
If the fetch response is not a list but rather a list wrapped in an object, like

``` js
{
   data: [ blah, blah, blah ]
}
```

then it needs to be parsed before calling `.length` on it to decide whether there are more pages to load. This is exactly what Backbone's `parse` function is used for. The default implementation of `parse` is to just pass the response through, so there's no need to check if it's there before calling it.

I don't think what's sent to `success` and `error` should be changed because people probably already depend on it working a certain way. It's less likely that anyone depends on `fetchSuccess`'s broken behavior in `strict: false` mode.

This fixes #7.
